### PR TITLE
Add role-based access control with OAuth2

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Python Debugger: Current File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal"
+    },
+    {
       "name": "Launch Mergington WebApp",
       "type": "debugpy",
       "request": "launch",

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces role-based access control to the application using OAuth2. Key changes include:

- Added an OAuth2PasswordBearer scheme for authentication.
- Implemented a `/token` endpoint for user login and token generation.
- Restricted access to activity-related endpoints based on user roles (teacher or student).
- Updated the `get_activities`, `signup_for_activity`, and `unregister_from_activity` endpoints to enforce authentication and role-based access control.

This ensures that only authorized users can perform specific actions, enhancing the security and integrity of the application.